### PR TITLE
Fix pytorch v1.2 above

### DIFF
--- a/deploy/src/classification/lib/src/netPytorch.cpp
+++ b/deploy/src/classification/lib/src/netPytorch.cpp
@@ -8,8 +8,10 @@
 namespace bonnetal {
 namespace classification {
 
-void torch_jit_module_compat(const torch::jit::script::Module& src,
-                             std::shared_ptr<torch::jit::script::Module>& module) {
+template <typename srcT>
+typename std::enable_if<std::is_convertible<srcT, torch::jit::script::Module>::value, void>::type
+  torch_jit_module_compat(srcT src,
+                        std::shared_ptr<torch::jit::script::Module>& module) {
   // Works for pytorch >= 1.2
   *module = src;
 }

--- a/deploy/src/segmentation/lib/src/netPytorch.cpp
+++ b/deploy/src/segmentation/lib/src/netPytorch.cpp
@@ -8,7 +8,9 @@
 namespace bonnetal {
 namespace segmentation {
 
-void torch_jit_module_compat(const torch::jit::script::Module& src,
+template <typename srcT>
+typename std::enable_if<std::is_copy_assignable<srcT>::value, void>::type
+  torch_jit_module_compat(srcT src,
                              std::shared_ptr<torch::jit::script::Module>& module) {
   // Works for pytorch >= 1.2
   *module = src;

--- a/deploy/src/segmentation/lib/src/netPytorch.cpp
+++ b/deploy/src/segmentation/lib/src/netPytorch.cpp
@@ -9,7 +9,7 @@ namespace bonnetal {
 namespace segmentation {
 
 template <typename srcT>
-typename std::enable_if<std::is_copy_assignable<srcT>::value, void>::type
+typename std::enable_if<std::is_convertible<srcT, torch::jit::script::Module>::value, void>::type
   torch_jit_module_compat(srcT src,
                              std::shared_ptr<torch::jit::script::Module>& module) {
   // Works for pytorch >= 1.2


### PR DESCRIPTION
This is related to my earlier pull request #15 . My changes were not compiling with Pytorch 1.1.

Now, I use enable_if to disable the function for Pytorch1.1
```cpp
template <typename srcT>
typename std::enable_if<std::is_convertible<srcT, torch::jit::script::Module>::value, void>::type
  torch_jit_module_compat(srcT src,
                        std::shared_ptr<torch::jit::script::Module>& module) {
  // Works for pytorch >= 1.2
  *module = src;
}
```
